### PR TITLE
Update minimum cmake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.5.0)
 project(sfml-project VERSION 0.1.0)
 
 # As std::auto_ptr was removed in C++17, sfml-audio fails to compile


### PR DESCRIPTION
Newer version of CMake does not support current minimum version.

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.
```